### PR TITLE
Fix reference to xlsx module name

### DIFF
--- a/lib/xlsx-style/ods.js
+++ b/lib/xlsx-style/ods.js
@@ -7,10 +7,10 @@ var ODS = {};
 var get_utils = function() {
 	if(typeof XLSX !== 'undefined') return XLSX.utils;
 	if(typeof module !== "undefined" && typeof require !== 'undefined') try {
-		return require('../' + 'xlsx').utils;
+		return require('../' + 'xlsx-style').utils;
 	} catch(e) {
-		try { return require('./' + 'xlsx').utils; }
-		catch(ee) { return require('xl' + 'sx').utils; }
+		try { return require('./' + 'xlsx-style').utils; }
+		catch(ee) { return require('xl' + 'sx-style').utils; }
 	}
 	throw new Error("Cannot find XLSX utils");
 };


### PR DESCRIPTION
Just got `Module not found: Error: Cannot resolve module 'xlsx' in /Users/marc/..../node_modules/mikuso-node-xlsx/lib/xlsx-style
 @ ./~/mikuso-node-xlsx/lib/xlsx-style/ods.js 13:21-41`. Looks like the `require`-call in `odj.js` still references the old module name.