### PR TITLE
Fixed webpack not finding correct module in ods.js

### DIFF
--- a/lib/xlsx-style/ods.js
+++ b/lib/xlsx-style/ods.js
@@ -6,12 +6,9 @@ var ODS = {};
 /* Open Document Format for Office Applications (OpenDocument) Version 1.2 */
 var get_utils = function() {
 	if(typeof XLSX !== 'undefined') return XLSX.utils;
-	if(typeof module !== "undefined" && typeof require !== 'undefined') try {
-		return require('../' + 'xlsx').utils;
-	} catch(e) {
-		try { return require('./' + 'xlsx').utils; }
-		catch(ee) { return require('xl' + 'sx').utils; }
-	}
+  var xlsx = require('./' + 'xlsx');
+  if (xlsx) return xlsx.utils;
+
 	throw new Error("Cannot find XLSX utils");
 };
 var has_buf = (typeof Buffer !== 'undefined');


### PR DESCRIPTION
While trying to add your fork to my project, webpack failed to build with the error `Cannot resolve module 'xlsx' in /Users/marc/..../node_modules/mikuso-node-xlsx/lib/xlsx-style @ ./~/mikuso-node-xlsx/lib/xlsx-style/ods.js 13:21-41`.

`ods.js` tries to find the main `xlsx` module at multiple locations. As only a single of these locations is correct, webpack fails to build as it cannot find all the referenced modules.

This change fixes the issue :) Btw: Thanks for making this library/fork, super useful 👍 